### PR TITLE
There is no generate function in new PDU

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -417,7 +417,7 @@ var createModem = function() {
 
     modem.sms = function(message, callback) {
         var i = 0;
-        var pdus = pdu.generate(message);
+        var pdus = pdu.stringify(message);
         var ids = [];
 
         //sendPDU executes 'AT+CMGS=X' command. The modem will give a '>' in response.


### PR DESCRIPTION
Replacing pdu.generate(message) with pdu.stringify(message)

After replacing these. We have to change sms sending function parameters.
`modem.sms({
	address:"03325200***",
	userData:"message to send",
}, callback);
`
Replacing text with userData, receiver with address and removing encoding 
